### PR TITLE
html_vignette() first exported in rmarkdown 0.2.65

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,6 @@ Depends:
     R (>= 3.1.0)
 Suggests:
     knitr,
-    rmarkdown (0.2.65),
+    rmarkdown (>= 0.2.65),
     microbenchmark
 VignetteBuilder: knitr


### PR DESCRIPTION
I had rmarkdown 0.2.64 and got this on my first attempt to install `lazyeval` (for the purpose of updating `dplyr`):

```
Error: processing vignette 'benchmark.Rmd' failed with diagnostics:
'html_vignette' is not an exported object from 'namespace:rmarkdown'
Execution halted
```
