### PR TITLE
no truncating when the expression is a bare symbol, i.e. not an expressi...

### DIFF
--- a/R/names.R
+++ b/R/names.R
@@ -31,9 +31,13 @@ auto_names <- function(x, max_width = 40) {
 }
 
 deparse_trunc <- function(x, width = getOption("width")) {
-  text <- deparse(x, width.cutoff = width)
-  if (length(text) == 1 && nchar(text) < width) return(text)
-
-  paste0(substr(text[1], 1, width - 3), "...")
+  if( typeof(x) == "symbol" ){
+    deparse(x)    
+  } else {
+    text <- deparse(x, width.cutoff = width)
+    if (length(text) == 1 && nchar(text) < width) return(text)
+    
+    paste0(substr(text[1], 1, width - 3), "...")
+  }
 }
 


### PR DESCRIPTION
...on. closes #19. related to hadley/dplyr#705

A test. @hadley not sure you want to add test suite for lazyeval. 

```
test_that( "auto_name does not truncate symbols (#19)", {
   x <- names(auto_name(lazy_dots(AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)))
   expect_false( grepl( "[.]", x ) )
})
```
