### PR TITLE
Fail with an informative error when promise has been forced

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Fixed an infinite loop in `lazy_dots(.follow_symbols = TRUE)` (#22, #24)
 
+* `lazy()` now fails with an informative error when it is applied on
+  an object that has already been evaluated (#23, @lionel-).
+
 # lazyeval 0.1.10
 
 * `as.lazy_dots()` gains a method for NULL, returning a zero-length

--- a/src/lazy.c
+++ b/src/lazy.c
@@ -5,6 +5,9 @@ SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
   // recurse until we find the real promise, not a promise of a promise
   // never go past the global environment
   while(TYPEOF(promise) == PROMSXP && env != R_GlobalEnv) {
+    if (PRENV(promise) == R_NilValue) {
+      Rf_error("Promise has already been forced");
+    }
 
     env = PRENV(promise);
     promise = PREXPR(promise);

--- a/vignettes/chained-promises.Rmd
+++ b/vignettes/chained-promises.Rmd
@@ -27,10 +27,10 @@ g1(a + b)
 In this case the process looks like this:
 
 1. Find the object that `x` is bound to.
-2. It's a promise, so find the expr it's bound to (`y`, a symbol) and the 
+2. It's a promise, so find the expr it's bound to (`y`, a symbol) and the
    environment in which it should be evaluated (the environment of `g()`).
 3. Since `x` is bound to a symbol, look up its value: it's bound to a promise.
-4. That promise has expression `a + b` and should be evaluated in the global 
+4. That promise has expression `a + b` and should be evaluated in the global
    environment.
 5. The expression is not a symbol, so stop.
 
@@ -51,4 +51,18 @@ b <- 1
 
 lazy_eval(g1(a + b))
 lazy_eval(g2(a + b))
+```
+
+Note that the resolution of chained promises only works with unevaluated objects. This is because R deletes the information about the environment associated with a promise when it has been forced, so that the garbage collector is allowed to remove the environment from memory in case it is no longer used. `lazy()` will fail with an error in such situations.
+
+```{r, eval = FALSE}
+var <- 0
+
+f3 <- function(x) {
+  force(x)
+  lazy(x)
+}
+
+f3(var)
+## Error: Promise has already been forced
 ```


### PR DESCRIPTION
This adds an informative error message when `lazy()` is used with an object that has been evaluated (see #23).

The internal R function `forcePromise()` sets PRENV to NULL when an object is evaluated, so there is no way to recover the environment information or to climb up the chain of promises.

An alternative behavior would be to stop at the point where the promise was forced and create a lazy object there, but  this would probably cause more confusion and subtle bugs.