### PR TITLE
Prevent lazy() from following expressions for lazily loaded objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * `lazy()` now fails with an informative error when it is applied on
   an object that has already been evaluated (#23, @lionel-).
 
+* `lazy()` no longer follows the expressions of lazily loaded objects
+  (#18, @lionel-).
+
 # lazyeval 0.1.10
 
 * `as.lazy_dots()` gains a method for NULL, returning a zero-length

--- a/src/lazy.c
+++ b/src/lazy.c
@@ -2,6 +2,9 @@
 #include <Rdefines.h>
 
 int is_dead_end(SEXP x) {
+  if (TYPEOF(x) != PROMSXP) {
+    return 1;
+  }
   if (TYPEOF(PREXPR(x)) == LANGSXP) {
     const char* name = CHAR(PRINTNAME(CAR(PREXPR(x))));
     if (strcmp(name, "lazyLoadDBfetch") == 0) {
@@ -31,7 +34,7 @@ SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
       SEXP obj = findVar(promise, env);
 
       dead_end = is_dead_end(obj);
-      if (!dead_end && TYPEOF(obj) == PROMSXP) {
+      if (!dead_end) {
         promise = obj;
       }
     }

--- a/src/lazy.c
+++ b/src/lazy.c
@@ -1,10 +1,22 @@
 #include <R.h>
 #include <Rdefines.h>
 
+int is_dead_end(SEXP x) {
+  if (TYPEOF(PREXPR(x)) == LANGSXP) {
+    const char* name = CHAR(PRINTNAME(CAR(PREXPR(x))));
+    if (strcmp(name, "lazyLoadDBfetch") == 0) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
 SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
   // recurse until we find the real promise, not a promise of a promise
-  // never go past the global environment
-  while(TYPEOF(promise) == PROMSXP && env != R_GlobalEnv) {
+  // stop when we find a lazily loaded object
+  int dead_end = 0;
+
+  while(TYPEOF(promise) == PROMSXP && !dead_end) {
     if (PRENV(promise) == R_NilValue) {
       Rf_error("Promise has already been forced");
     }
@@ -17,7 +29,9 @@ SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
     // keep going on up
     if (follow_symbols && TYPEOF(promise) == SYMSXP) {
       SEXP obj = findVar(promise, env);
-      if (TYPEOF(obj) == PROMSXP) {
+
+      dead_end = is_dead_end(obj);
+      if (!dead_end && TYPEOF(obj) == PROMSXP) {
         promise = obj;
       }
     }
@@ -39,6 +53,8 @@ SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
 
   return lazy;
 }
+
+
 
 SEXP make_lazy(SEXP name, SEXP env, SEXP follow_symbols_) {
   SEXP promise = findVar(name, env);

--- a/tests/testthat/test-lazy.R
+++ b/tests/testthat/test-lazy.R
@@ -1,26 +1,42 @@
 context("lazy")
 
 
+lazy_caller <- function(arg) {
+  lazy(arg)
+}
+outer_fun <- function(arg) {
+  lazy_caller(arg)
+}
+
+
+test_that("basic lazy() functionality works", {
+  expect_equal(lazy_caller(0)$expr, 0)
+  expect_equal(lazy_caller("char")$expr, "char")
+  expect_equal(lazy_caller(sym)$expr, as.name("sym"))
+  expect_equal(lazy_caller(call("name"))$expr, quote(call("name")))
+})
+
+test_that("lazy() works with nested promises", {
+  expect_equal(outer_fun(0)$expr, 0)
+  expect_equal(outer_fun("char")$expr, "char")
+  expect_equal(outer_fun(sym)$expr, as.name("sym"))
+  expect_equal(outer_fun(call("name"))$expr, quote(call("name")))
+})
+
 test_that("lazy() does not unpack lazily loaded objects", {
-  fun <- function(arg) {
-    lazyeval::lazy(arg)
-  }
-  lazy <- fun(mean)
+  lazy <- lazy_caller(mean)
   expect_equal(deparse(lazy$expr), "mean")
 
-  fun2 <- function(arg) {
-    fun(arg)
-  }
-  nested_lazy <- fun2(mean)
+  nested_lazy <- outer_fun(mean)
   expect_equal(deparse(lazy$expr), "mean")
 
-  fun3 <- function() {
+  outer_fun2 <- function() {
     list(
-      lazy = fun(mean),
+      lazy = lazy_caller(mean),
       env = environment()
     )
   }
-  embedded_lazy <- fun3()
+  embedded_lazy <- outer_fun2()
   expect_identical(embedded_lazy$lazy$expr, as.name("mean"))
   expect_identical(embedded_lazy$lazy$env, embedded_lazy$env)
 })

--- a/tests/testthat/test-lazy.R
+++ b/tests/testthat/test-lazy.R
@@ -1,0 +1,26 @@
+context("lazy")
+
+
+test_that("lazy() does not unpack lazily loaded objects", {
+  fun <- function(arg) {
+    lazyeval::lazy(arg)
+  }
+  lazy <- fun(mean)
+  expect_equal(deparse(lazy$expr), "mean")
+
+  fun2 <- function(arg) {
+    fun(arg)
+  }
+  nested_lazy <- fun2(mean)
+  expect_equal(deparse(lazy$expr), "mean")
+
+  fun3 <- function() {
+    list(
+      lazy = fun(mean),
+      env = environment()
+    )
+  }
+  embedded_lazy <- fun3()
+  expect_identical(embedded_lazy$lazy$expr, as.name("mean"))
+  expect_identical(embedded_lazy$lazy$env, embedded_lazy$env)
+})


### PR DESCRIPTION
This makes `promise_as_lazy()` check that promise expressions are not `lazyLoadDBfetch` calls. Fixes #18.