### PR TITLE
Failing test, and suggestion for fix

### DIFF
--- a/src/lazy.c
+++ b/src/lazy.c
@@ -6,7 +6,11 @@ int is_dead_end(SEXP x) {
     return 1;
   }
   if (TYPEOF(PREXPR(x)) == LANGSXP) {
-    const char* name = STRING_VALUE(CAR(PREXPR(x)));
+    SEXP pr = CAR(PREXPR(x));
+    if (TYPEOF(pr) != SYMSXP) {
+      return 0;
+    }
+    const char* name = CHAR(PRINTNAME(pr));
     if (strcmp(name, "lazyLoadDBfetch") == 0) {
       return 1;
     }

--- a/src/lazy.c
+++ b/src/lazy.c
@@ -6,7 +6,7 @@ int is_dead_end(SEXP x) {
     return 1;
   }
   if (TYPEOF(PREXPR(x)) == LANGSXP) {
-    const char* name = CHAR(PRINTNAME(CAR(PREXPR(x))));
+    const char* name = STRING_VALUE(CAR(PREXPR(x)));
     if (strcmp(name, "lazyLoadDBfetch") == 0) {
       return 1;
     }

--- a/tests/testthat/test-lazy.R
+++ b/tests/testthat/test-lazy.R
@@ -40,3 +40,8 @@ test_that("lazy() does not unpack lazily loaded objects", {
   expect_identical(embedded_lazy$lazy$expr, as.name("mean"))
   expect_identical(embedded_lazy$lazy$env, embedded_lazy$env)
 })
+
+test_that("lazy() works for double-colon operator", {
+  expect_error(lazy <- lazy_caller(stats::runif(10)), NA)
+  expect_error(nested_lazy <- outer_fun(stats::runif(10)), NA)
+})


### PR DESCRIPTION
for regression introduced in #30, CC @lionel- .

I'm not at all sure if 106e79c is the best thing to do. Perhaps it's simpler to just check if the value is a `SYMSXP` and bail out early if it's not. Any suggestions?

Note that this error doesn't appear yet in the CRAN version.