### PR TITLE
Support arguments passed as non-promises. Fix NAMED on promise.

### DIFF
--- a/src/lazy.c
+++ b/src/lazy.c
@@ -18,10 +18,10 @@ SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
     if (follow_symbols && TYPEOF(promise) == SYMSXP) {
       SEXP obj = findVar(promise, env);
 
-      if (TYPEOF(obj) != PROMSXP)
+      if (obj == R_MissingArg || obj == R_UnboundValue)
         break;
 
-      if (is_lazy_load(obj))
+      if (TYPEOF(obj) == PROMSXP && is_lazy_load(obj))
         break;
 
       promise = obj;
@@ -30,6 +30,8 @@ SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
 
   // Make named list for output
   SEXP lazy = PROTECT(allocVector(VECSXP, 2));
+  if (NAMED(promise) < 2)
+    SET_NAMED(promise, 2);
   SET_VECTOR_ELT(lazy, 0, promise);
   SET_VECTOR_ELT(lazy, 1, env);
 


### PR DESCRIPTION
This fix adds support for arguments passed as non-promises, which is needed for "lazy" to work with the byte-code compiler. The byte-code compiler passes compile-time constants to closures as non-promises, which confuses "lazy" (and e.g. causes tests failure with the mosaic package). The modification puts the semantics of "lazy" a bit closer to that of "substitute". The modification also bumps NAMED on the promise before returning it, again putting it closer to "substitute".