### PR TITLE
support for r 3.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: lazyeval
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Title: Lazy (Non-Standard) Evaluation
 Description: An alternative approach to non-standard evaluation using
     formulas. Provides a full implementation of LISP style 'quasiquotation',
@@ -11,7 +11,7 @@ Authors@R: c(
 License: GPL-3
 LazyData: true
 Depends:
-    R (>= 3.1.0)
+    R (>= 3.0.0)
 Suggests:
     knitr,
     rmarkdown (>= 0.2.65),

--- a/src/name.c
+++ b/src/name.c
@@ -22,12 +22,33 @@ SEXP as_name(SEXP x) {
   }
 }
 
+SEXP shallow_duplicate(SEXP list)
+{
+  if (TYPEOF(list) != LISTSXP)
+    Rf_errorcall(R_NilValue, "'shallow_duplicate' can only handle LISTSXP objects for now.");
+  SEXP new = R_NilValue;
+  SEXP next, a;
+  /**** Could be done in a single pass */
+  /**** Don't need to protect since CONS does */
+  for (next = list; next != R_NilValue; next = CDR(next))
+    new = Rf_cons(R_NilValue, new);
+  for (next = list, a = new;
+       next != R_NilValue;
+       next = CDR(next), a = CDR(a)) {
+    SETCAR(a, CAR(next));
+    SET_TAG(a, TAG(next));
+    /**** ATTRIB?? */
+    SET_NAMED(CAR(a), 2); /* may not be necessary */
+  }
+  return new;
+}
+
 SEXP lhs_name(SEXP x) {
   if (TYPEOF(x) != VECSXP)
     Rf_errorcall(R_NilValue, "`x` must be a list (not a %s)", Rf_type2char(TYPEOF(x)));
 
   int n = Rf_length(x);
-  SEXP x2 = PROTECT(Rf_shallow_duplicate(x));
+  SEXP x2 = PROTECT(shallow_duplicate(x));
 
   SEXP names = Rf_getAttrib(x2, R_NamesSymbol);
   if (names == R_NilValue) {


### PR DESCRIPTION
Add support for r `3.0.0` to allow upstream packages like `tibble` to support `3.0.0` as well.