### PR TITLE
Fix bug where env already declared before lazyeval loaded

### DIFF
--- a/R/formula.R
+++ b/R/formula.R
@@ -88,7 +88,7 @@ f_lhs <- function(f) {
 #' @rdname f_rhs
 #' @useDynLib lazyeval env
 f_env <- function(f) {
-  .Call(env, f)
+  .Call("env", f)
 }
 
 #' @export


### PR DESCRIPTION
This simple fix will prevent bugs in lazyeval when `env` is already declared, and should not alter existing functionality